### PR TITLE
Use regular GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Reset test release
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.RELEASE_ANTIVIRUS_GITHUB_ACCESS_TOKEN_PBOT4 }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             let releaseId = ${{ matrix.release-id }};
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           owner: Particular
           repo: virus-scan-action
           tag: ${{ matrix.tag }}
-          github-access-token: ${{ secrets.RELEASE_ANTIVIRUS_GITHUB_ACCESS_TOKEN_PBOT4 }}
+          github-access-token: ${{ secrets.GITHUB_TOKEN }}
           slack-token: ${{ secrets.SLACK_TOKEN }}
           slack-channel: automation-testing
       - name: Check result


### PR DESCRIPTION
Given the fact that CI passes without `secrets.RELEASE_ANTIVIRUS_GITHUB_ACCESS_TOKEN_PBOT4`, it's clear that a specialized token isn't needed. We don't even need to alter the [workflow permissions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to make it work.

This does nothing on its own, but it shows that the [workflow in RepoStandards](https://github.com/Particular/RepoStandards/blob/master/.github/workflows/virus-scan.yml) can be changed to use `secrets.GITHUB_TOKEN` instead of `secrets.RELEASE_ANTIVIRUS_GITHUB_ACCESS_TOKEN_PBOT4`, and one use for @particularbot4 will be eliminated.

https://github.com/Particular/RepoStandards/pull/80 will implement this in RepoStandards.