### PR TITLE
Update asset download request to use correct api url so it works for both public and private repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
           core.exportVariable('RELEASE_HTML_URL', release.data.html_url);
           
           for (const assetInfo of release.data.assets) {
-            let asset = await github.request(assetInfo.browser_download_url);
+            let asset = await github.request(assetInfo.url, { headers: { accept: 'application/octet-stream' } });
             await fs.writeFile('github-release-assets/' + assetInfo.name, Buffer.from(asset.data), () => {});
           }
           


### PR DESCRIPTION
Using the download url is fine for public repos, but it fails on private ones.  This switches to using the api url, which should use the workflow GITHUB_TOKEN and work for both types of repositories.